### PR TITLE
Updated OVH URL - added function to get IP

### DIFF
--- a/custom_components/ovh/__init__.py
+++ b/custom_components/ovh/__init__.py
@@ -63,7 +63,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     session = async_get_clientsession(hass)
 
-    result = await _update_ovh(session, domain, user, password)
+    current_ip = await _get_current_ip(session)
+    if not current_ip:
+        return False
+
+    result = await _update_ovh(session, domain, user, password, current_ip)
 
     if not result:
         return False
@@ -77,10 +81,25 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def _update_ovh(session, domain, user, password):
+async def _get_current_ip(session):
+    """Get current public IP from ifconfig.co."""
+    try:
+        async with async_timeout.timeout(10):
+            async with session.get("https://ifconfig.co/ip") as resp:
+                ip = (await resp.text()).strip()
+                _LOGGER.info("Got IP from ifconfig.co: %s", ip)
+
+                return ip
+
+    except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+        _LOGGER.error("Failed to get IP from ifconfig.co: %s", err)
+
+        return None
+
+async def _update_ovh(session, domain, user, password, current_ip):
     """Update OVH."""
     try:
-        url = f"https://{user}:{password}@{HOST}?system=dyndns&hostname={domain}"
+        url = f"https://{user}:{password}@{HOST}?system=dyndns&hostname={domain}&myip={current_ip}"
         async with async_timeout.timeout(TIMEOUT):
             resp = await session.get(url)
             body = await resp.text()

--- a/custom_components/ovh/__init__.py
+++ b/custom_components/ovh/__init__.py
@@ -26,7 +26,7 @@ DOMAIN = "ovh"
 DEFAULT_INTERVAL = timedelta(minutes=15)
 
 TIMEOUT = 30
-HOST = "www.ovh.com/nic/update"
+HOST = "dns.eu.ovhapis.com/nic/update"
 
 OVH_ERRORS = {
     "nohost": "Hostname supplied does not exist under specified account",


### PR DESCRIPTION
I got always the wrong IP-Address for my OVH Subdomain. 
After adapting the HOST-URL to the one in the [official documentation ](https://help.ovhcloud.com/csm/en-ie-dns-dynhost?id=kb_article_view&sysparm_article=KB0051641#3-automate-the-dynhost-update) and adding a function, which is checking the current IP, it's working again.